### PR TITLE
fix(combo): resolve badge overlap, text truncation, and state reset o…

### DIFF
--- a/COMBO_REFACTOR_SUMMARY.md
+++ b/COMBO_REFACTOR_SUMMARY.md
@@ -212,3 +212,164 @@ $wire.set('selections', merged)
 3. **Multi-condition combos:** The architecture supports multiple category conditions in the same combo. Each gets its own Alpine component, each broadcasts to the same window event. The sticky bar aggregates all of them via `conditionStats`.
 
 4. **Variant-only combos (all product-type):** `categoryConditionCount = 0` → `allCategoryFulfilled()` returns `true` immediately. The progress section is hidden. CTA is enabled once all product variant selections are made (tracked via `$wire.selections` reactivity).
+
+---
+
+## Phase 2: UI/UX Refinements
+
+**Date:** 2026-07-11  
+**Commit:** `fix(combo): resolve badge overlap, text truncation, and state reset on tier change`
+
+Three QA bugs were identified after Phase 1 and corrected surgically:
+
+---
+
+### P2.1 Badge Overlap Fix
+
+**Problem:** The "الأوفر" tier badge used `absolute -top-2.5 left-1/2 -translate-x-1/2` positioning, causing it to overlap the pricing text inside the card and destroy readability.
+
+**Fix:** Removed all `absolute` positioning. The tier button (`<button>`) was changed from `relative p-4` to `flex flex-col items-center gap-1 p-4`. The badge `<span>` is now the **first child** in the flex column, flowing naturally above the pricing content without any overlap.
+
+```blade
+{{-- Before --}}
+<button class="... relative p-4 ...">
+    <span class="absolute -top-2.5 left-1/2 -translate-x-1/2 ...">الأوفر</span>
+    <div>...pricing...</div>
+
+{{-- After --}}
+<button class="... flex flex-col items-center gap-1 p-4 ...">
+    <span class="...">الأوفر</span>  {{-- naturally first, no overlap --}}
+    <div>...pricing...</div>
+```
+
+---
+
+### P2.2 Product Name Truncation Fix
+
+**Problem:** Long Arabic product names (e.g. "فلور فايوليت أثير مخمرية") were being cut off by `truncate` inside a flexbox row with no overflow protection, making product names unreadable on small screens.
+
+**Fix:** Applied the strict Flexbox constraint pattern across the product row:
+
+| Container | Old Classes | New Classes |
+|---|---|---|
+| Outer row | `flex items-center gap-3` | `flex items-center gap-2` |
+| Image | `w-14 h-14 ... shrink-0` | `w-12 h-12 ... flex-shrink-0` |
+| Text | `flex-1 min-w-0` + `truncate` | `flex-1 min-w-0` + **`break-words`** |
+| Stepper | `flex items-center gap-1.5 shrink-0` | `w-24 flex-shrink-0 flex items-center justify-center gap-1.5` |
+
+**Key rule:** `flex-shrink-0` on edges (image + stepper) prevents them from squeezing. `min-w-0` on the text container allows it to shrink below its natural content width. `break-words` lets the text wrap to a second line instead of overflowing.
+
+---
+
+### P2.3 State Preservation on Tier Change (Upgrade/Downgrade)
+
+**Problem:** The original `wire:key="cat-cond-{{ $conditionId }}-{{ $selectedTierIndex }}"` caused Livewire to **destroy and recreate** the Alpine component on every tier change, wiping all user-selected quantities back to zero.
+
+**Root cause:** Livewire's `wire:key` is equivalent to Vue's `:key` — a key change forces DOM destruction and reinitialisation of the Alpine component.
+
+**Fix — Three coordinated changes:**
+
+#### 1. Remove `$selectedTierIndex` from `wire:key`
+```blade
+{{-- Before --}}
+wire:key="cat-cond-{{ $conditionId }}-{{ $selectedTierIndex }}"
+
+{{-- After --}}
+wire:key="cat-cond-{{ $conditionId }}"
+```
+The Alpine component now survives tier changes.
+
+#### 2. Add `tierQuantities` array + `overflow` getter to Alpine `x-data`
+```blade
+@php
+    $tierQuantitiesJson = json_encode(array_column($tiers, 'quantity'));
+@endphp
+```
+```js
+x-data="{
+    limit: {{ $data['required_quantity'] }},
+    tierQuantities: {{ $tierQuantitiesJson }},  // e.g. [5, 3, 1]
+
+    get overflow() {
+        return Math.max(0, this.total - this.limit);
+    },
+    ...
+}"
+```
+
+#### 3. Add `$watch` in `x-init` to reactively update `limit`
+```js
+x-init="
+    broadcast();
+    $watch('$wire.selectedTierIndex', function(idx) {
+        limit = tierQuantities[idx];
+        broadcast();
+    });
+"
+```
+When the user selects a different tier, `$wire.selectedTierIndex` changes server-side. Alpine's `$watch` fires, updates `limit` to the new tier's quantity, and re-broadcasts the updated state.
+
+**Upgrade scenario (3→5):** `limit` increases. Existing quantities (≤3) are within the new limit. User simply continues adding 2 more items.
+
+**Downgrade scenario (5→3):** `limit` decreases. If `total > limit`, `overflow > 0`. Card header pill and progress bar turn **red**. The sticky bar shows an Arabic warning and the CTA remains disabled.
+
+---
+
+### P2.4 Overflow Warning in Sticky Bar (Downgrade)
+
+**Problem:** No user feedback when a downgrade causes `total > limit`.
+
+**Fix:** The sticky summary bar's `x-data` gained an `overflowQuantity` getter and `isReady()` was updated to guard against it:
+
+```js
+get overflowQuantity() {
+    return Math.max(0, this.totalSelected - this.totalRequired);
+},
+
+isReady(wireSelections) {
+    return this.overflowQuantity === 0 &&
+           this.allCategoryFulfilled() &&
+           this.allProductsFulfilled(wireSelections);
+},
+```
+
+**UI:** When `overflowQuantity > 0`, the normal progress row is hidden and replaced with a localized Arabic warning:
+
+```blade
+<div x-show="overflowQuantity > 0" class="... bg-red-50 border border-red-200 ...">
+    <span x-text="'اختياراتك الحالية تتجاوز العرض المختار. يرجى إزالة ' + overflowQuantity + ' قطعة.'"></span>
+</div>
+<div x-show="overflowQuantity === 0 && totalRequired > 0">
+    ... normal progress ...
+</div>
+```
+
+The tier-reset watcher (`$watch('$wire.selectedTierIndex', function(){ conditionStats = {}; })`) was **removed** from the sticky bar's `x-init` — it is no longer needed since Alpine components no longer reinitialise on tier change.
+
+---
+
+### P2.5 Card Visual States (3-way color coding)
+
+The per-card progress pill and progress bar now support three states:
+
+| State | Condition | Color |
+|---|---|---|
+| In progress | `total < limit` | Violet |
+| Fulfilled | `total === limit` | Green |
+| Overflow (downgrade) | `total > limit` | Red |
+
+The success banner (`"اختياراتك مكتملة! 🎉"`) now uses `x-show="total === limit"` (strict equality) instead of `total >= limit`, so it does NOT appear during an overflow state.
+
+---
+
+### P2 Dry Run Trace
+
+| Step | Action | State |
+|---|---|---|
+| 1 | Select Tier 1 (limit=3) | `limit=3, total=0` |
+| 2 | Add 3 items | `total=3, overflow=0` → green pill, CTA active |
+| 3 | Switch to Tier 2 (limit=5) | `$watch` fires → `limit=5`. `quantities` unchanged. `total=3, overflow=0` → violet pill |
+| 4 | Add 2 more items | `total=5, overflow=0` → green pill, CTA active |
+| 5 | Switch back to Tier 1 (limit=3) | `$watch` fires → `limit=3`. `quantities` unchanged. `total=5, overflow=2` → red pill, sticky bar warning shown, CTA disabled |
+| 6 | Click `−` twice on any items | `total=3, overflow=0` → green pill, warning disappears, normal progress shows, CTA active |
+

--- a/resources/views/livewire/store/combo-landing-page.blade.php
+++ b/resources/views/livewire/store/combo-landing-page.blade.php
@@ -62,23 +62,23 @@
                             type="button"
                             wire:click="selectTier({{ $index }})"
                             @class([
-                                'relative p-4 rounded-2xl border-2 text-center transition-all duration-200 cursor-pointer',
+                                'flex flex-col items-center gap-1 p-4 rounded-2xl border-2 text-center transition-all duration-200 cursor-pointer',
                                 'col-span-2'                                                              => $index === 0,
                                 'border-violet-600 bg-violet-50 ring-2 ring-violet-200 shadow-md'        => $selectedTierIndex === $index,
                                 'border-gray-200 bg-white hover:border-violet-400 hover:bg-gray-50'      => $selectedTierIndex !== $index,
                             ])
                         >
-                            {{-- "Best Value" badge — only on the featured (index 0) tier --}}
+                            {{-- "Best Value" badge in natural flow — no absolute positioning --}}
                             @if($index === 0)
-                                <span class="absolute -top-2.5 left-1/2 -translate-x-1/2 whitespace-nowrap bg-violet-600 text-white text-xs font-bold px-3 py-0.5 rounded-full shadow-sm">
+                                <span class="inline-flex items-center bg-violet-600 text-white text-xs font-bold px-3 py-0.5 rounded-full shadow-sm whitespace-nowrap">
                                     الأوفر 🔥
                                 </span>
                             @endif
 
-                            <div class="text-base font-bold text-gray-900 mt-1">
+                            <div class="text-base font-bold text-gray-900">
                                 {{ $tier['quantity'] }} {{ $tier['quantity'] == 1 ? 'قطعة' : 'قطع' }}
                             </div>
-                            <div class="font-bold mt-1 {{ $index === 0 ? 'text-2xl text-violet-700' : 'text-lg text-violet-600' }}">
+                            <div class="font-bold {{ $index === 0 ? 'text-2xl text-violet-700' : 'text-lg text-violet-600' }}">
                                 @if($tier['discount_type'] === 'fixed_price')
                                     {{ number_format($tier['fixed_price'], 0) }} ج.م
                                 @else
@@ -87,7 +87,7 @@
                             </div>
 
                             @if($selectedTierIndex === $index)
-                                <div class="mt-2 flex justify-center">
+                                <div class="flex justify-center">
                                     <svg class="w-5 h-5 text-violet-600" fill="currentColor" viewBox="0 0 20 20">
                                         <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
                                     </svg>
@@ -109,6 +109,7 @@
                 ->map(fn($d, $id) => ['conditionId' => (int)$id, 'has_variants' => (bool)$d['has_variants']])
                 ->values()
                 ->toArray();
+            $tierQuantitiesJson = json_encode(array_column($tiers, 'quantity'));
         @endphp
 
         {{-- ═══════════════════════════════════════════════════════════════════
@@ -213,7 +214,8 @@
                 {{-- ───────────────────────────────────────────────────────────
                      CATEGORY-TYPE CONDITION — Smart Quantity Selector
                      Alpine manages all +/− state client-side (zero latency).
-                     wire:key forces re-init when tier (and thus limit) changes.
+                     State is PRESERVED across tier changes via $watch on
+                     $wire.selectedTierIndex — quantities survive upgrade/downgrade.
                 ─────────────────────────────────────────────────────────────── --}}
                 @elseif($data['type'] === 'category')
                     @php
@@ -226,16 +228,21 @@
                         id="piece-{{ $conditionId }}"
                         class="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden scroll-mt-20
                                {{ $conditionHasAnyError ? 'ring-2 ring-red-300' : '' }}"
-                        wire:key="cat-cond-{{ $conditionId }}-{{ $selectedTierIndex }}"
+                        wire:key="cat-cond-{{ $conditionId }}"
                         x-data="{
-                            conditionId: {{ $conditionId }},
-                            limit: {{ $data['required_quantity'] }},
-                            products: {{ $productsJson }},
-                            quantities: {},
+                            conditionId:     {{ $conditionId }},
+                            limit:           {{ $data['required_quantity'] }},
+                            tierQuantities:  {{ $tierQuantitiesJson }},
+                            products:        {{ $productsJson }},
+                            quantities:      {},
                             variantSelections: {},
 
                             get total() {
                                 return Object.values(this.quantities).reduce(function(s, v){ return s + v; }, 0);
+                            },
+
+                            get overflow() {
+                                return Math.max(0, this.total - this.limit);
                             },
 
                             isFulfilled() {
@@ -298,7 +305,13 @@
                                 });
                             }
                         }"
-                        x-init="broadcast()"
+                        x-init="
+                            broadcast();
+                            $watch('$wire.selectedTierIndex', function(idx) {
+                                limit = tierQuantities[idx];
+                                broadcast();
+                            });
+                        "
                     >
                         {{-- Card header with live progress pill --}}
                         <div class="bg-gray-50 px-4 py-3 border-b border-gray-100">
@@ -307,14 +320,14 @@
                                     اختر من: {{ $data['category_name'] }}
                                 </h2>
                                 <span class="shrink-0 text-sm font-bold px-3 py-1 rounded-full transition-colors duration-200"
-                                      :class="total === limit ? 'bg-green-100 text-green-700' : 'bg-violet-50 text-violet-700'">
+                                      :class="total > limit ? 'bg-red-100 text-red-700' : total === limit ? 'bg-green-100 text-green-700' : 'bg-violet-50 text-violet-700'">
                                     <span x-text="total"></span> / {{ $data['required_quantity'] }}
                                 </span>
                             </div>
                             {{-- Animated progress bar --}}
                             <div class="mt-2 h-1.5 bg-gray-200 rounded-full overflow-hidden">
                                 <div class="h-full rounded-full transition-all duration-300"
-                                     :class="total === limit ? 'bg-green-500' : 'bg-violet-500'"
+                                     :class="total > limit ? 'bg-red-500' : total === limit ? 'bg-green-500' : 'bg-violet-500'"
                                      :style="'width: ' + Math.min(Math.round(total / limit * 100), 100) + '%'">
                                 </div>
                             </div>
@@ -326,13 +339,13 @@
                                 <div class="px-4 py-3">
 
                                     {{-- Product row: image · name+price · stepper --}}
-                                    <div class="flex items-center gap-3">
+                                    <div class="flex items-center gap-2">
                                         <img src="{{ $product['image'] }}"
                                              alt="{{ $product['name'] }}"
-                                             class="w-14 h-14 object-contain bg-gray-50 rounded-xl border border-gray-100 shrink-0">
+                                             class="w-12 h-12 object-contain bg-gray-50 rounded-xl border border-gray-100 flex-shrink-0">
 
                                         <div class="flex-1 min-w-0">
-                                            <p class="font-semibold text-gray-900 text-sm leading-snug truncate">{{ $product['name'] }}</p>
+                                            <p class="font-semibold text-gray-900 text-sm leading-snug break-words">{{ $product['name'] }}</p>
                                             @if($product['is_on_sale'] ?? false)
                                                 <p class="text-xs mt-0.5">
                                                     <span class="text-gray-400 line-through">{{ number_format($product['regular_price'], 0) }}</span>
@@ -344,7 +357,7 @@
                                         </div>
 
                                         {{-- +/− Quantity Stepper --}}
-                                        <div class="flex items-center gap-1.5 shrink-0">
+                                        <div class="w-24 flex-shrink-0 flex items-center justify-center gap-1.5">
                                             {{-- Minus --}}
                                             <button
                                                 type="button"
@@ -425,7 +438,7 @@
 
                         {{-- Limit-reached success banner --}}
                         <div
-                            x-show="total >= limit"
+                            x-show="total === limit"
                             x-transition:enter="transition ease-out duration-200"
                             x-transition:enter-start="opacity-0"
                             x-transition:enter-end="opacity-100"
@@ -505,7 +518,11 @@
             },
 
             isReady(wireSelections) {
-                return this.allCategoryFulfilled() && this.allProductsFulfilled(wireSelections);
+                return this.overflowQuantity === 0 && this.allCategoryFulfilled() && this.allProductsFulfilled(wireSelections);
+            },
+
+            get overflowQuantity() {
+                return Math.max(0, this.totalSelected - this.totalRequired);
             },
 
             onConditionUpdate(detail) {
@@ -513,7 +530,6 @@
             }
         }"
         x-init="
-            $watch('$wire.selectedTierIndex', function(){ conditionStats = {}; });
             var stickyEl = $el;
             var ro = new ResizeObserver(function(entries) {
                 for (var i = 0; i < entries.length; i++) {
@@ -528,7 +544,19 @@
 
             {{-- Progress row (only when category conditions exist) --}}
             @if($categoryConditionCount > 0)
-                <div class="flex items-center justify-between mb-2.5 gap-3" x-show="totalRequired > 0">
+                {{-- Overflow warning (downgrade scenario) --}}
+                <div x-show="overflowQuantity > 0"
+                     x-transition
+                     class="flex items-center gap-2 mb-2.5 px-3 py-2 bg-red-50 border border-red-200 rounded-xl text-sm text-red-700 font-medium">
+                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                    </svg>
+                    <span x-text="'اختياراتك الحالية تتجاوز العرض المختار. يرجى إزالة ' + overflowQuantity + ' قطعة.'"></span>
+                </div>
+
+                {{-- Normal progress row --}}
+                <div class="flex items-center justify-between mb-2.5 gap-3"
+                     x-show="overflowQuantity === 0 && totalRequired > 0">
                     <div class="flex items-center gap-1.5 text-sm">
                         <span class="font-bold transition-colors duration-200"
                               :class="totalSelected === totalRequired && totalRequired > 0 ? 'text-green-600' : 'text-violet-700'"
@@ -551,7 +579,7 @@
                 {{-- Mini progress bar --}}
                 <div class="h-1 bg-gray-200 rounded-full mb-3 overflow-hidden" x-show="totalRequired > 0">
                     <div class="h-full rounded-full transition-all duration-300"
-                         :class="totalSelected === totalRequired && totalRequired > 0 ? 'bg-green-500' : 'bg-violet-500'"
+                         :class="overflowQuantity > 0 ? 'bg-red-500' : totalSelected === totalRequired && totalRequired > 0 ? 'bg-green-500' : 'bg-violet-500'"
                          :style="totalRequired > 0 ? 'width: ' + Math.min(Math.round(totalSelected / totalRequired * 100), 100) + '%' : 'width:0'">
                     </div>
                 </div>


### PR DESCRIPTION
…n tier change

Phase 2 QA fixes for the Alpine.js Smart Quantity Selector:

- Badge overlap: replaced absolute positioning with flex-col in-flow layout so the 'الأوفر' badge sits above pricing text without overlapping
- Product name truncation: applied flex-shrink-0 on image/stepper edges, min-w-0 + break-words on the text container; removed truncate class
- State preservation: removed \ from wire:key so Alpine survives tier changes; added tierQuantities array + \ on \.selectedTierIndex to update limit reactively, quantities preserved
- Overflow guard: added overflow getter and overflowQuantity to sticky bar; isReady() blocked when total > limit; Arabic warning replaces progress row on downgrade; progress bar and pill turn red on overflow
- Removed tier-reset watcher (conditionStats={}) from sticky bar x-init
- Updated COMBO_REFACTOR_SUMMARY.md with full Phase 2 documentation